### PR TITLE
Added automatic table creation if non-existent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ instead.
 The example below assumes you have an ASP.NET Core backend playing reverse proxy to a legacy ASP.NET 4.x app
 and share the user session via cookie that gets decrypted via the DB-backed keys.
 
-> [!CAUTION]
-> The table name `DataProtectionKeys` is hard-coded and needs to be created in the target database.
-> See [`SQL_CreateTable.sql`](src/SQL_CreateTable.sql) for details.
+> [!NOTE]
+> The `DataProtectionKeys` table is created automatically on first use when the connection string has
+> `CREATE TABLE` permission. If the table already exists the check is a no-op. If creation fails
+> (e.g. a least-privilege connection string), a warning is written to `System.Diagnostics.Trace` and
+> startup continues. Pass `ensureTableCreated: false` to any entry point to opt out entirely and
+> manage the schema yourself via [`SQL_CreateTable.sql`](src/SQL_CreateTable.sql).
 
 ### ASP.NET Core (.NET 8)
 
@@ -46,7 +49,9 @@ builder.Services.AddDbContext<DataProtectionDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DataProtection")));
 
 builder.Services.AddDataProtection()
-    .PersistKeysToSqlServer(builder.Configuration.GetConnectionString("DataProtection")!)    
+    // Table is created automatically if it does not exist and the login has CREATE TABLE permission.
+    // Pass ensureTableCreated: false to opt out.
+    .PersistKeysToSqlServer(builder.Configuration.GetConnectionString("DataProtection")!)
     .SetApplicationName("iis-app-name");
 
 // example to use SSO via shared cookie with ASP.NET 4 
@@ -86,6 +91,8 @@ app.UseCookieAuthentication(new CookieAuthenticationOptions
     ExpireTimeSpan = TimeSpan.FromMinutes(120),
     TicketDataFormat = new AspNetTicketDataFormat(
         new DataProtectorShim(
+            // Table is created automatically if it does not exist and the login has CREATE TABLE permission.
+            // Pass ensureTableCreated: false to opt out.
             SqlDataProtectionProvider.Create(connectionString, "iis-app-name")
                 .CreateProtector(
                     "Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationMiddleware",

--- a/src/DataProtectionBuilderExtensions.cs
+++ b/src/DataProtectionBuilderExtensions.cs
@@ -18,13 +18,26 @@ public static class DataProtectionBuilderExtensions
     /// <summary>
     ///     Registers the <see cref="EfXmlRepository" /> using EF 6.
     /// </summary>
+    /// <param name="builder">The <see cref="IDataProtectionBuilder" /> to configure.</param>
+    /// <param name="connectionString">The SQL Server connection string.</param>
+    /// <param name="ensureTableCreated">
+    ///     When <see langword="true" /> (the default), attempts to create the
+    ///     <c>DataProtectionKeys</c> table if it does not already exist. A warning is logged and
+    ///     startup continues if the connection string lacks <c>CREATE TABLE</c> permission.
+    ///     Set to <see langword="false" /> to opt out and manage the schema manually.
+    /// </param>
     public static IDataProtectionBuilder PersistKeysToSqlServer(this IDataProtectionBuilder builder,
-        string connectionString)
+        string connectionString, bool ensureTableCreated = true)
     {
+        if (ensureTableCreated)
+        {
+            using DataProtectionDbContext context = new DataProtectionDbContext(connectionString);
+            DataProtectionSchema.EnsureTableExists(context);
+        }
+
         builder.AddKeyManagementOptions(options =>
         {
-            options.XmlRepository = new EfXmlRepository(() => new DataProtectionDbContext(connectionString
-            ));
+            options.XmlRepository = new EfXmlRepository(() => new DataProtectionDbContext(connectionString));
         });
 
         return builder;
@@ -43,16 +56,30 @@ public static class DataProtectionBuilderExtensions
     /// <summary>
     ///     Registers the <see cref="EfXmlRepository" /> using EF Core.
     /// </summary>
+    /// <param name="builder">The <see cref="IDataProtectionBuilder" /> to configure.</param>
+    /// <param name="connectionString">The SQL Server connection string.</param>
+    /// <param name="ensureTableCreated">
+    ///     When <see langword="true" /> (the default), attempts to create the
+    ///     <c>DataProtectionKeys</c> table if it does not already exist. A warning is logged and
+    ///     startup continues if the connection string lacks <c>CREATE TABLE</c> permission.
+    ///     Set to <see langword="false" /> to opt out and manage the schema manually.
+    /// </param>
     public static IDataProtectionBuilder PersistKeysToSqlServer(this IDataProtectionBuilder builder,
-        string connectionString)
+        string connectionString, bool ensureTableCreated = true)
     {
-        builder.AddKeyManagementOptions(options =>
+        DbContextOptions<DataProtectionDbContext> options = new DbContextOptionsBuilder<DataProtectionDbContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+
+        if (ensureTableCreated)
         {
-            options.XmlRepository = new EfXmlRepository(() => new DataProtectionDbContext(
-                new DbContextOptionsBuilder<DataProtectionDbContext>()
-                    .UseSqlServer(connectionString)
-                    .Options
-            ));
+            using DataProtectionDbContext context = new DataProtectionDbContext(options);
+            DataProtectionSchema.EnsureTableExists(context);
+        }
+
+        builder.AddKeyManagementOptions(keyOptions =>
+        {
+            keyOptions.XmlRepository = new EfXmlRepository(() => new DataProtectionDbContext(options));
         });
 
         return builder;

--- a/src/DataProtectionSchema.cs
+++ b/src/DataProtectionSchema.cs
@@ -1,0 +1,47 @@
+// ReSharper disable UnusedType.Global
+
+using System.Diagnostics;
+#if NETFRAMEWORK
+using System.Data.Entity;
+#endif
+
+#if NETCOREAPP
+using Microsoft.EntityFrameworkCore;
+#endif
+
+namespace Nefarius.Legacy.DataProtector;
+
+internal static class DataProtectionSchema
+{
+    private const string CreateTableSql =
+        "IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'DataProtectionKeys') " +
+        "CREATE TABLE [DataProtectionKeys] (" +
+        "[Id] NVARCHAR(200) NOT NULL PRIMARY KEY," +
+        "[XmlData] NVARCHAR(MAX) NULL," +
+        "[LastModified] DATETIME NOT NULL DEFAULT (GETUTCDATE())" +
+        ");";
+
+    /// <summary>
+    ///     Attempts to create the <c>DataProtectionKeys</c> table if it does not exist.
+    ///     Logs a warning via <see cref="Trace" /> and returns on any failure.
+    /// </summary>
+    internal static void EnsureTableExists(DataProtectionDbContext context)
+    {
+        try
+        {
+#if NETCOREAPP
+            context.Database.ExecuteSqlRaw(CreateTableSql);
+#elif NETFRAMEWORK
+            context.Database.ExecuteSqlCommand(CreateTableSql);
+#endif
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning(
+                "[Nefarius.Legacy.DataProtector] Could not automatically create the DataProtectionKeys table. " +
+                "Ensure the connection string has CREATE TABLE permission, or create the table manually using " +
+                "the SQL_CreateTable.sql script shipped with the package. " +
+                $"Exception: {ex.Message}");
+        }
+    }
+}

--- a/src/SQL_CreateTable.sql
+++ b/src/SQL_CreateTable.sql
@@ -1,6 +1,6 @@
-CREATE TABLE DataProtectionKeys
+CREATE TABLE [DataProtectionKeys]
 (
-    Id           NVARCHAR(200) PRIMARY KEY,
-    XmlData      NVARCHAR(MAX),
-    LastModified DATETIME DEFAULT GETDATE()
+    [Id]           NVARCHAR(200) NOT NULL PRIMARY KEY,
+    [XmlData]      NVARCHAR(MAX) NULL,
+    [LastModified] DATETIME      NOT NULL DEFAULT (GETUTCDATE())
 );

--- a/src/SqlDataProtectionProvider.cs
+++ b/src/SqlDataProtectionProvider.cs
@@ -20,8 +20,21 @@ public static class SqlDataProtectionProvider
     /// </summary>
     /// <param name="connectionString">The SQL Server connection string.</param>
     /// <param name="applicationName">The unique name of this application within the data protection system.</param>
-    public static IDataProtectionProvider Create(string connectionString, string applicationName)
+    /// <param name="ensureTableCreated">
+    ///     When <see langword="true" /> (the default), attempts to create the
+    ///     <c>DataProtectionKeys</c> table if it does not already exist. A warning is logged and
+    ///     startup continues if the connection string lacks <c>CREATE TABLE</c> permission.
+    ///     Set to <see langword="false" /> to opt out and manage the schema manually.
+    /// </param>
+    public static IDataProtectionProvider Create(string connectionString, string applicationName,
+        bool ensureTableCreated = true)
     {
+        if (ensureTableCreated)
+        {
+            using DataProtectionDbContext context = new DataProtectionDbContext(connectionString);
+            DataProtectionSchema.EnsureTableExists(context);
+        }
+
         return DataProtectionProvider.Create(
             new DirectoryInfo(
                 /* NOTE: this is just to avoid Argument(Null)Exception, the value is not used */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQL Server data-protection key storage can now automatically ensure the `DataProtectionKeys` table exists on first use when permissions allow.
  * Added an `ensureTableCreated` option to enable/disable this behavior; when disabled, setup proceeds without attempting schema creation.

* **Documentation**
  * Updated README guidance for EF-backed SQL Server key storage, including the automatic table creation behavior and the opt-out configuration.

* **Other**
  * Updated the SQL schema defaults to use UTC timestamps for `LastModified`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->